### PR TITLE
Custom functions in chain & better reprs

### DIFF
--- a/examples/validations.py
+++ b/examples/validations.py
@@ -51,13 +51,17 @@ def main() -> None:
 
     earth_age = v.int().custom(_validate_earth_age)
     print_title("Custom Validation - Earth Age")
-    print_example("Is 4.543 billion years a valid Earth age?", earth_age(4_543_000_000))
-    print_example("Is 4.543 million years a valid Earth age?", earth_age(4_543_000))
+    print_example(
+        "Is 4.543 billion years a valid Earth age?", earth_age.check(4_543_000_000)
+    )
+    print_example(
+        "Is 4.543 million years a valid Earth age?", earth_age.check(4_543_000)
+    )
 
     # You can create your own reusable validation types or extend existing ones
     class SlackChannel(v.V6eStr):
         @override
-        def _parse(self, raw: t.Any) -> str:
+        def parse_raw(self, raw: t.Any) -> str:
             if not isinstance(raw, str):
                 raise ValueError(f"Value {raw!r} is not a valid slack channel")
 
@@ -78,7 +82,9 @@ def main() -> None:
     )
 
     # Type checking example
+    print_title("Type-checking example")
     my_validation = v.int().gte(8).lte(4)
+    print(my_validation)
     t.reveal_type(my_validation)
     t.reveal_type(my_validation.check)
     t.reveal_type(my_validation.safe_parse)

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import v6e as v
+from tests.util import (
+    V6eCase,
+    V6eTest,
+    generate_tests,
+)
+
+
+def _validate_earth_age(x: int) -> None:
+    if x != 4_543_000_000:
+        raise ValueError("The Earth is 4.543 billion years old. Try 4543000000.")
+
+
+def _capitalize_if_one_word(s: str) -> str:
+    if " " in s:
+        raise ValueError(f"Value {s} must be a single word")
+    return s.capitalize()
+
+
+all_test_cases = generate_tests(
+    V6eTest(
+        fn=[v.int().custom(_validate_earth_age)],
+        success_args=[4_543_000_000, "4543000000"],
+        failure_args=[0],
+    ),
+    V6eTest(
+        fn=[v.str().custom(_capitalize_if_one_word)],
+        success_args=["hello", "world!"],
+        success_ret_values=["Hello", "World!"],
+        failure_args=["two words?", "tHis sHouLd faiL..."],
+    ),
+)
+
+
+@all_test_cases
+def test_all(test: V6eCase):
+    pass

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,20 @@
+from pytest import mark
+
+import v6e as v
+
+
+@mark.parametrize(
+    "validation,expected",
+    [
+        (
+            v.V6eInt().gte(5).lt(15).multiple_of(5),
+            "v6e.V6eInt().gte(5).lt(15).multiple_of(5)",
+        ),
+        (
+            v.str().contains("foo").regex(r"[a-z0-9]{2}"),
+            "v6e.str().contains('foo').regex('[a-z0-9]{2}')",
+        ),
+    ],
+)
+def test_base_class_repr(validation, expected):
+    assert str(validation) == expected

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -3,6 +3,10 @@ from pytest import mark
 import v6e as v
 
 
+def _custom_fn(x: int) -> None:
+    raise ValueError(f"{x} shall not pass!")
+
+
 @mark.parametrize(
     "validation,expected",
     [
@@ -13,6 +17,10 @@ import v6e as v
         (
             v.str().contains("foo").regex(r"[a-z0-9]{2}"),
             "v6e.str().contains('foo').regex('[a-z0-9]{2}')",
+        ),
+        (
+            v.int().custom(_custom_fn),
+            "v6e.int().custom(_custom_fn)",
         ),
     ],
 )

--- a/v6e/__init__.py
+++ b/v6e/__init__.py
@@ -1,16 +1,17 @@
 from v6e.exceptions import ValidationException
+from v6e.types import utils
 from v6e.types.base import V6eType
 from v6e.types.boolean import V6eBool
 from v6e.types.calendar import V6eDateTime, V6eTimeDelta
 from v6e.types.numbers import V6eFloat, V6eInt
 from v6e.types.string import V6eStr
 
-bool = V6eBool
-int = V6eInt
-float = V6eFloat
-str = V6eStr
-datetime = V6eDateTime
-timedelta = V6eTimeDelta
+bool = utils.alias(V6eBool, "bool")
+int = utils.alias(V6eInt, "int")
+float = utils.alias(V6eFloat, "float")
+str = utils.alias(V6eStr, "str")
+datetime = utils.alias(V6eDateTime, "datetime")
+timedelta = utils.alias(V6eTimeDelta, "timedelta")
 
 __all__ = [
     "V6eType",

--- a/v6e/types/base.py
+++ b/v6e/types/base.py
@@ -60,8 +60,6 @@ ParserFn: t.TypeAlias = t.Callable[t.Concatenate[V6eTypeType, T, P], T | None]
 
 def parser(wrapped_fun: ParserFn[V6eTypeType, T, P]):
     def _impl(self: V6eTypeType, *args: P.args, **kwargs: P.kwargs) -> V6eTypeType:
-        repr = utils.repr_fun(wrapped_fun, *args, **kwargs)
-
         def _fn(value: T):
             try:
                 res = wrapped_fun(self, value, *args, **kwargs)
@@ -72,6 +70,7 @@ def parser(wrapped_fun: ParserFn[V6eTypeType, T, P]):
                 result=value if res is None else res,
             )
 
+        repr = utils.repr_fun(wrapped_fun, *args, **kwargs)
         self._chain(repr, _fn)
         return self
 

--- a/v6e/types/boolean.py
+++ b/v6e/types/boolean.py
@@ -2,8 +2,7 @@ import typing as t
 
 from typing_extensions import override
 
-from v6e.types.base import V6eType
-from v6e.types.utils import parser
+from v6e.types.base import V6eType, parser
 
 TRUE_BOOL_STR_LITERALS: set[str] = {"true", "yes", "y"}
 FALSE_BOOL_STR_LITERALS: set[str] = {"false", "no", "n"}
@@ -11,7 +10,7 @@ FALSE_BOOL_STR_LITERALS: set[str] = {"false", "no", "n"}
 
 class V6eBool(V6eType[bool]):
     @override
-    def _parse(self, raw):
+    def parse_raw(self, raw):
         if isinstance(raw, str):
             raw_lower = raw.lower()
             if (

--- a/v6e/types/comparable.py
+++ b/v6e/types/comparable.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from v6e.types.base import V6eType
-from v6e.types.utils import parser
+from v6e.types.base import V6eType, parser
 
 
 class _Comparable(t.Protocol):

--- a/v6e/types/numbers.py
+++ b/v6e/types/numbers.py
@@ -4,8 +4,7 @@ import typing as t
 
 from typing_extensions import override
 
-from v6e.types.comparable import V6eComparableMixin
-from v6e.types.utils import parser
+from v6e.types.comparable import V6eComparableMixin, parser
 
 Numeric = t.TypeVar("Numeric", bound=int | float)
 
@@ -48,7 +47,7 @@ class V6eNumericMixin(V6eComparableMixin[Numeric]):
 
 class V6eInt(V6eNumericMixin[int]):
     @override
-    def _parse(self, raw):
+    def parse_raw(self, raw):
         value = int(raw)
         if value != float(raw):
             raise ValueError(f"The value {raw!r} is not a valid integer.")
@@ -57,5 +56,5 @@ class V6eInt(V6eNumericMixin[int]):
 
 class V6eFloat(V6eNumericMixin[float]):
     @override
-    def _parse(self, raw):
+    def parse_raw(self, raw):
         return float(raw)

--- a/v6e/types/sequences.py
+++ b/v6e/types/sequences.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from v6e.types.base import V6eType
-from v6e.types.utils import parser
+from v6e.types.base import V6eType, parser
 
 T = t.TypeVar("T", bound=t.Sequence)
 

--- a/v6e/types/string.py
+++ b/v6e/types/string.py
@@ -2,9 +2,9 @@ import re
 
 from typing_extensions import override
 
+from v6e.types.base import parser
 from v6e.types.comparable import V6eComparableMixin
 from v6e.types.sequences import V6eSequenceMixin
-from v6e.types.utils import parser
 
 EMAIL = re.compile(
     r"^(?!\.)(?!.*\.\.)([A-Z0-9_'+\-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$",
@@ -18,7 +18,7 @@ UUID = re.compile(
 
 class V6eStr(V6eComparableMixin[str], V6eSequenceMixin[str]):
     @override
-    def _parse(self, raw):
+    def parse_raw(self, raw):
         if not isinstance(raw, str):
             raise ValueError(f"The value {raw!r} is not a valid string.")
         return raw

--- a/v6e/types/utils.py
+++ b/v6e/types/utils.py
@@ -2,45 +2,38 @@ from __future__ import annotations
 
 import typing as t
 
-from v6e.exceptions import ValidationException
-from v6e.types.base import ParseResult, V6eType
+from v6e.types.base import ParserFn, V6eTypeType
 
-V = t.TypeVar("V")
-T = t.TypeVar("T", bound=V6eType)
 P = t.ParamSpec("P")
+T = t.TypeVar("T")
 
-ParserFn: t.TypeAlias = t.Callable[t.Concatenate[T, V, P], V | None]
 
-
-def _repr_fun(wrapped_fun: ParserFn[T, V, P], *args: P.args, **kwargs: P.kwargs):
-    repr = f"{wrapped_fun.__name__}"
+def repr_fun(fn: ParserFn[V6eTypeType, T, P], *args: P.args, **kwargs: P.kwargs):
+    repr = f"{fn.__name__}"
     if not args and not kwargs:
         return repr
 
     all_args_str = "".join(
         [
-            *[str(a) for a in args],
-            *[f"{k}={v}" for k, v in kwargs.items()],
+            *[f"{a!r}" for a in args],
+            *[f"{k}={v!r}" for k, v in kwargs.items()],
         ]
     )
     return f"{repr}({all_args_str})"
 
 
-def parser(wrapped_fun: ParserFn[T, V, P]):
-    def _impl(self: T, *args: P.args, **kwargs: P.kwargs) -> T:
-        repr = _repr_fun(wrapped_fun, *args, **kwargs)
+def alias(cls: type[V6eTypeType], name: str) -> t.Callable[[], V6eTypeType]:
+    """
+    Utility to alias a V6eType with a different name
+    so that they're represented differently. For example:
+    ```python
+    print(V6eBool().gt(5))  # v6e.V6eBool().gt(5)
+    bool = alias(V6eBool, "bool")
+    print(bool().gt(5))  # v6e.bool().gt(5)
+    ```
+    """
 
-        def _fn(value: V):
-            try:
-                res = wrapped_fun(self, value, *args, **kwargs)
-            except (ValueError, TypeError, ValidationException) as e:
-                return ParseResult(error_message=str(e))
+    def inner():
+        return cls(alias=name)
 
-            return ParseResult(
-                result=value if res is None else res,
-            )
-
-        self._chain(repr, _fn)
-        return self
-
-    return _impl
+    return inner

--- a/v6e/types/utils.py
+++ b/v6e/types/utils.py
@@ -13,10 +13,15 @@ def repr_fun(fn: ParserFn[V6eTypeType, T, P], *args: P.args, **kwargs: P.kwargs)
     if not args and not kwargs:
         return repr
 
+    def _arg_to_str(arg: t.Any):
+        if isinstance(arg, t.Callable):
+            return arg.__name__
+        return f"{arg!r}"
+
     all_args_str = "".join(
         [
-            *[f"{a!r}" for a in args],
-            *[f"{k}={v!r}" for k, v in kwargs.items()],
+            *map(_arg_to_str, args),
+            *[f"{k}={_arg_to_str(v)}" for k, v in kwargs.items()],
         ]
     )
     return f"{repr}({all_args_str})"


### PR DESCRIPTION
## Custom chainable functions
Introduces syntax for users to chain custom parsers into existing types:

```python
import v6e as v

def is_div_by_three(x: int):
    if x % 3 != 0:
        raise ValueError(f"Value {x} is not divisible by three!")

my_validation = v.int().custom(is_div_by_three)
```

## Better string representations

Printing a V6E parser now displays the chain of functions with arguments correctly