### PR TITLE
Add union type parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,25 @@ my_validation.parse("21")  # Ok -> Returns 21 (int)
 my_validation.parse(54)  # Err -> Raises a ValidationException
 ```
 
-**Chaing your validations and transformations**
+**Chaining your validations and transformations**
 ```python
 my_validation = v.str().trim().starts_with("foo").ends_with("foo").regex(r"^[a-z0-9]*$")
 my_validation.parse("  foo12")  # Ok -> Returns 'foo12' (str)
 my_validation.parse("12foo  ")  # Ok -> Returns '12foo' (str)
 my_validation.parse("1foo2")  # Err -> Raises a ValidationException
+```
+
+**Handling multiple possible types**
+```python
+union = v.str().starts_with("foo") | v.int().gte(5)
+
+union.parse("foobar")  # Ok -> Returns 'foobar' (str)
+union.parse("1foo2")  # Err -> Raises a ValidationException
+
+union.parse(5)  # Ok -> Returns 5 (int)
+union.parse(3)  # Err -> Raises a ValidationException
+
+union.parse(None)  # Err -> Raises a ValidationException
 ```
 
 **Custom validations**

--- a/examples/validations.py
+++ b/examples/validations.py
@@ -19,9 +19,10 @@ def print_title(x: str) -> None:
     print(BLUE + "\n" + x + DEFAULT)
 
 
-def print_example(prompt: str, result: bool) -> None:
+def print_example(parser: v.V6eType, value: t.Any) -> None:
+    result = parser.check(value)
     color = GREEN if result else RED
-    print(prompt, color + str(result) + DEFAULT)
+    print(f"Does {value!r} parse with {parser}? {color}{result}{DEFAULT}")
 
 
 # --- DEMO ---
@@ -29,66 +30,59 @@ def main() -> None:
     # Basic usage
     can_drink = v.int().gte(21)
     print_title("Basic - Age")
-    print_example("With age 21 can you drink?", can_drink.check(21))
-    print_example("With age 20 can you drink?", can_drink.check(20))
+    print_example(can_drink, 21)
+    print_example(can_drink, 20)
 
-    # You can "AND" multiple validations
+    # You can chain multiple checks
     interview_channel = v.str().starts_with("#").regex("interview.*[0-9]{2}-[0-9]{2}")
-    print_title("AND Validations - Slack Channel")
-    print_example(
-        "Is channel #interview-foo-feb-01-12 an interview slack channel?",
-        interview_channel.check("#interview-foo-feb-01-12"),
-    )
-    print_example(
-        "Is channel #foo-feb-01-12 an interview slack channel?",
-        interview_channel.check("#foo-feb-01-12"),
-    )
+    print_title("Chaining Parsers - Slack Channel")
+    print_example(interview_channel, "#interview-foo-feb-01-12")
+    print_example(interview_channel, "#foo-feb-01-12")
 
-    # You can create your own custom validations
+    # You can OR multiple parsers
+    union = v.str().starts_with("foo") | v.int().gte(5)
+    print_title("Union of parsers - foo or 5")
+    print_example(union, "foobar")
+    print_example(union, "1foo2")
+    print_example(union, 5)
+    print_example(union, 4)
+    print_example(union, None)
+
+    # You can create your own custom parsers
     def _validate_earth_age(x: int) -> None:
         if x != 4_543_000_000:
             raise ValueError("The Earth is 4.543 billion years old. Try 4543000000.")
 
     earth_age = v.int().custom(_validate_earth_age)
-    print_title("Custom Validation - Earth Age")
-    print_example(
-        "Is 4.543 billion years a valid Earth age?", earth_age.check(4_543_000_000)
-    )
-    print_example(
-        "Is 4.543 million years a valid Earth age?", earth_age.check(4_543_000)
-    )
+    print_title("Custom Parser - Earth Age")
+    print_example(earth_age, 4_543_000_000)
+    print_example(earth_age, 4_543_000)
 
-    # You can create your own reusable validation types or extend existing ones
+    # You can create your own reusable parser types or extend existing ones
     class SlackChannel(v.V6eStr):
         @override
         def parse_raw(self, raw: t.Any) -> str:
-            if not isinstance(raw, str):
-                raise ValueError(f"Value {raw!r} is not a valid slack channel")
-
-            if re.search("^#[a-z0-9-]$", raw) is None:
+            parsed: str = super().parse_raw(raw)
+            if re.search(r"^#[a-z0-9-]+$", parsed) is None:
                 raise v.ValidationException(
                     "Slack channels must start with '#' and contain only letters, numbers, and dashes"
                 )
 
-            return raw
+            return parsed
 
     foo_slack_channel = SlackChannel().contains("foo")
-    print_title("Reusable Validation Type - Slack Channel")
-    print_example(
-        "Is #foo-bar a valid slack channel?", foo_slack_channel.check("#foo-bar")
-    )
-    print_example(
-        "Is foo-bar a valid slack channel?", foo_slack_channel.check("foo-bar")
-    )
+    print_title("Reusable Parser Type - Slack Channel")
+    print_example(foo_slack_channel, "#foo-bar")
+    print_example(foo_slack_channel, "foo-bar")
 
     # Type checking example
     print_title("Type-checking example")
-    my_validation = v.int().gte(8).lte(4)
-    print(my_validation)
-    t.reveal_type(my_validation)
-    t.reveal_type(my_validation.check)
-    t.reveal_type(my_validation.safe_parse)
-    t.reveal_type(my_validation.parse)
+    my_parser = v.int().gte(8).lte(4)
+    print(my_parser)
+    t.reveal_type(my_parser)
+    t.reveal_type(my_parser.check)
+    t.reveal_type(my_parser.safe_parse)
+    t.reveal_type(my_parser.parse)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "v6e"
 description = "A simple, type-safe, and extensible Python validations framework"
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -13,7 +13,7 @@ from v6e.types.boolean import FALSE_BOOL_STR_LITERALS, TRUE_BOOL_STR_LITERALS
 all_test_cases = generate_tests(
     # ----- Running the parsing logic -----
     V6eTest(
-        fn=v.bool(),
+        fn=[v.bool()],
         success_args=[
             True,
             False,
@@ -26,12 +26,12 @@ all_test_cases = generate_tests(
     ),
     # ----- Running all possible checks -----
     V6eTest(
-        fn=v.bool().is_true(),
+        fn=[v.bool().is_true()],
         success_args=[True, 1, *TRUE_BOOL_STR_LITERALS],
         failure_args=[False, 0, *FALSE_BOOL_STR_LITERALS],
     ),
     V6eTest(
-        fn=v.bool().is_false(),
+        fn=[v.bool().is_false()],
         success_args=[False, 0, *FALSE_BOOL_STR_LITERALS],
         failure_args=[True, 1, *TRUE_BOOL_STR_LITERALS],
     ),

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -22,6 +22,10 @@ def _custom_fn(x: int) -> None:
             v.int().custom(_custom_fn),
             "v6e.int().custom(_custom_fn)",
         ),
+        (
+            v.int().gte(5) | v.str().contains("a"),
+            "v6e.int().gte(5) | v6e.str().contains('a')",
+        ),
     ],
 )
 def test_base_class_repr(validation, expected):

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -12,7 +12,7 @@ from tests.util import (
 all_test_cases = generate_tests(
     # ----- Running the parsing logic -----
     V6eTest(
-        fn=v.str(),
+        fn=[v.str()],
         success_args=["a"],
         failure_args=[1, False, datetime.now(), timedelta()],
     ),
@@ -48,6 +48,7 @@ all_test_cases = generate_tests(
         success_args=["a", "abc", "cba"],
         failure_args=["cbd", "bc", ""],
     ),
+    # ----- Running string checks -----
     V6eTest(
         fn=[v.str().starts_with("a")],
         success_args=["a", "abc"],
@@ -58,7 +59,6 @@ all_test_cases = generate_tests(
         success_args=["a", "bca"],
         failure_args=["abcd", "bac", "ac"],
     ),
-    # ----- Running string checks -----
     V6eTest(
         fn=[v.str().regex(r"^[0-9a-z]+$")],
         success_args=["abc123", "123", "abc", "a"],

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import v6e as v
+from tests.util import (
+    V6eCase,
+    V6eTest,
+    generate_tests,
+)
+
+all_test_cases = generate_tests(
+    V6eTest(
+        fn=[v.int().gte(4).lte(5) | v.str().regex("^a|b$")],
+        success_args=[4, 5, "a", "b"],
+        success_ret_values=[4, 5, "a", "b"],
+        failure_args=[3, "c", datetime.now(), timedelta()],
+    ),
+)
+
+
+@all_test_cases
+def test_all(test: V6eCase):
+    pass

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,7 +14,7 @@ T = t.TypeVar("T")
 @t.final
 @dataclass
 class V6eTest(t.Generic[T]):
-    fn: v.V6eType[T] | list[v.V6eType[T]]
+    fn: list[v.V6eType[T]]
     success_args: list[t.Any] | None = None
     success_ret_values: list[T] | None = None
     failure_args: list[t.Any] | None = None
@@ -42,7 +42,7 @@ class V6eTest(t.Generic[T]):
 @dataclass
 class V6eCase(t.Generic[T]):
     fn: v.V6eType[T]
-    arg: list[t.Any] | None = None
+    arg: t.Any | None = None
     ret_value: T | None = None
     fails: bool = False
     exc: t.Type[Exception] = v.ValidationException

--- a/uv.lock
+++ b/uv.lock
@@ -111,7 +111,7 @@ wheels = [
 
 [[package]]
 name = "v6e"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/v6e/types/base.py
+++ b/v6e/types/base.py
@@ -91,7 +91,7 @@ class V6eType(ABC, t.Generic[T]):
         cp._checks.append(Check(name, check))
         return cp
 
-    def _or(self, other: V6eType[C]) -> _Union[T, C]:
+    def __or__(self, other: V6eType[C]) -> _Union[T, C]:
         return _Union(self, other)
 
     @t.final
@@ -140,11 +140,15 @@ class _Union(V6eType[T | C]):
     def __init__(self, left: V6eType[T], right: V6eType[C]) -> None:
         super().__init__()
         self.left = left
-        self.rigth = right
+        self.right = right
 
     @override
     def parse_raw(self, raw: t.Any) -> T | C:
         try:
             return self.left.parse(raw)
         except ValidationException:
-            return self.rigth.parse(raw)
+            return self.right.parse(raw)
+
+    @override
+    def __repr__(self):
+        return f"{self.left} | {self.right}"

--- a/v6e/types/sequences.py
+++ b/v6e/types/sequences.py
@@ -21,17 +21,3 @@ class V6eSequenceMixin(V6eType[T]):
             raise ValueError(
                 f"{value} does not contain {x}",
             )
-
-    @parser
-    def starts_with(self, value: T, x: T):
-        if value[0] != x:
-            raise ValueError(
-                f"{value} does not start with {x}",
-            )
-
-    @parser
-    def ends_with(self, value: T, x: T):
-        if value[-1] != x:
-            raise ValueError(
-                f"{value} does not start with {x}",
-            )

--- a/v6e/types/string.py
+++ b/v6e/types/string.py
@@ -24,6 +24,20 @@ class V6eStr(V6eComparableMixin[str], V6eSequenceMixin[str]):
         return raw
 
     @parser
+    def starts_with(self, value: str, x: str):
+        if not value.startswith(x):
+            raise ValueError(
+                f"{value} does not start with {x}",
+            )
+
+    @parser
+    def ends_with(self, value: str, x: str):
+        if not value.endswith(x):
+            raise ValueError(
+                f"{value} does not start with {x}",
+            )
+
+    @parser
     def regex(self, value: str, pattern: str):
         if re.search(pattern, value) is None:
             raise ValueError(


### PR DESCRIPTION
This PR adds syntax to `OR` multiple parsers together. For example:
```python
union = v.str().starts_with("foo") | v.int().gte(5)

union.parse("foobar")  # Ok -> Returns 'foobar' (str)
union.parse("1foo2")  # Err -> Raises a ValidationException

union.parse(5)  # Ok -> Returns 5 (int)
union.parse(3)  # Err -> Raises a ValidationException

union.parse(None)  # Err -> Raises a ValidationException
```